### PR TITLE
CCW: Implement GitHub issue #37 for Crossbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to Crossbar will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - Unreleased
+
+### ✨ Features
+
+#### Hierarchical Submenu Support (BitBar/Argos Compatible)
+
+- **Parser Enhancement**: `OutputParser` now detects and parses hierarchical menu structures using the BitBar/Argos `--` prefix notation
+  - Lines without `--` are root level (0)
+  - Lines with `--` are submenu items (level 1)
+  - Lines with `----` are nested submenus (level 2), and so on
+- **TrayService Update**: Recursive menu building for platform-appropriate rendering on Linux, macOS, and Windows
+- **Action Support**: Submenu items support `bash` and `href` attributes for executing commands and opening URLs
+- **Depth Limit**: Maximum of 10 nesting levels to prevent infinite loops
+- **Example Plugin**: Added `submenu-demo.1m.lua` demonstrating hierarchical menus
+
+### 📚 Documentation
+
+- Expanded submenu documentation in `plugin-development.md` with practical examples
+- Added GNOME Shell limitations note for deep submenus
+
 ## [1.0.0] - 2025-12-01
 
 ### 🎉 Initial Release

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -180,9 +180,9 @@ Bold item | font=bold
 | `templateImage` | Template image (macOS)   | `templateImage=...`            |
 | `dropdown`      | Include in dropdown      | `dropdown=false`               |
 
-#### Nested Submenus
+#### Nested Submenus (BitBar/Argos Compatible)
 
-Use `--` prefix for submenu items:
+Use the `--` prefix notation to create hierarchical submenus. Each `--` pair adds one level of nesting:
 
 ```
 Main Title
@@ -190,9 +190,53 @@ Main Title
 Parent Item
 --Child Item 1
 --Child Item 2
-----Grandchild Item
+----Grandchild Item 1
+----Grandchild Item 2
+------Great-grandchild
 Another Item
 ```
+
+**How it works:**
+- Lines without `--` prefix are root-level items (level 0)
+- Lines with `--` prefix become children of the preceding parent (level 1)
+- Lines with `----` prefix are grandchildren (level 2)
+- And so on for deeper nesting
+
+**Submenu items can have attributes:**
+
+```
+Settings
+---
+Actions
+--Open File | bash=/usr/bin/open
+--Visit Website | href=https://example.com | color=blue
+--Delete | color=red
+----Confirm Delete | bash=rm -rf ./temp
+```
+
+**Practical example - System Monitor:**
+
+```
+System
+---
+CPU
+--Usage: 45%
+--Cores: 8
+--Temperature
+----Core 0: 65C
+----Core 1: 62C
+Memory
+--Used: 8 GB / 16 GB
+--Swap: 2 GB / 4 GB
+Disk
+--/: 120 GB / 500 GB
+--/home: 80 GB / 250 GB
+```
+
+**Limitations:**
+- Maximum depth of 10 levels (to prevent infinite loops)
+- GNOME Shell may not render deep submenus correctly (known limitation)
+- Recommended to keep depth under 3 levels for best compatibility
 
 #### Examples
 

--- a/lib/core/output_parser.dart
+++ b/lib/core/output_parser.dart
@@ -72,7 +72,7 @@ class OutputParser {
       displayText = parsed.text;
     }
 
-    final menu = <MenuItem>[];
+    final flatItems = <_FlatMenuItem>[];
     var inMenu = false;
 
     for (var i = 1; i < lines.length; i++) {
@@ -84,38 +84,20 @@ class OutputParser {
       }
 
       if (!inMenu) continue;
+      if (line.trim().isEmpty) continue;
 
-      final trimmedLine = line.trim();
-      if (trimmedLine.isEmpty) continue;
+      // Detect hierarchy level by counting leading "--" pairs
+      final level = _getHierarchyLevel(line);
+      final contentLine = _stripHierarchyPrefix(line);
 
-      if (trimmedLine.contains('|')) {
-        final parts = trimmedLine.split('|');
-        final itemText = parts[0].trim();
-        String? bash;
-        String? href;
-        String? itemColor;
+      if (contentLine.isEmpty) continue;
 
-        for (var k = 1; k < parts.length; k++) {
-          final attr = parts[k].trim();
-          if (attr.startsWith('bash=')) {
-            bash = attr.substring(5);
-          } else if (attr.startsWith('href=')) {
-            href = attr.substring(5);
-          } else if (attr.startsWith('color=')) {
-            itemColor = attr.substring(6);
-          }
-        }
-
-        menu.add(MenuItem(
-          text: itemText,
-          bash: bash,
-          href: href,
-          color: itemColor,
-        ));
-      } else {
-        menu.add(MenuItem(text: trimmedLine));
-      }
+      final menuItem = _parseMenuItemLine(contentLine);
+      flatItems.add(_FlatMenuItem(level: level, item: menuItem));
     }
+
+    // Build hierarchical structure from flat list
+    final menu = _buildHierarchy(flatItems);
 
     return PluginOutput(
       pluginId: pluginId,
@@ -124,6 +106,119 @@ class OutputParser {
       color: colorStr != null ? _parseColor(colorStr) : null,
       menu: menu,
     );
+  }
+
+  /// Counts the hierarchy level by detecting leading "--" pairs.
+  /// Example: "Item" = 0, "--Item" = 1, "----Item" = 2
+  static int _getHierarchyLevel(String line) {
+    var level = 0;
+    var index = 0;
+
+    while (index + 1 < line.length &&
+        line[index] == '-' &&
+        line[index + 1] == '-') {
+      level++;
+      index += 2;
+    }
+
+    return level;
+  }
+
+  /// Strips the leading "--" hierarchy prefix from a line.
+  static String _stripHierarchyPrefix(String line) {
+    var index = 0;
+
+    while (index + 1 < line.length &&
+        line[index] == '-' &&
+        line[index + 1] == '-') {
+      index += 2;
+    }
+
+    return line.substring(index).trim();
+  }
+
+  /// Parses a single menu item line (after stripping hierarchy prefix).
+  static MenuItem _parseMenuItemLine(String line) {
+    if (line.contains('|')) {
+      final parts = line.split('|');
+      final itemText = parts[0].trim();
+      String? bash;
+      String? href;
+      String? itemColor;
+
+      for (var k = 1; k < parts.length; k++) {
+        final attr = parts[k].trim();
+        if (attr.startsWith('bash=')) {
+          bash = attr.substring(5);
+        } else if (attr.startsWith('href=')) {
+          href = attr.substring(5);
+        } else if (attr.startsWith('color=')) {
+          itemColor = attr.substring(6);
+        }
+      }
+
+      return MenuItem(
+        text: itemText,
+        bash: bash,
+        href: href,
+        color: itemColor,
+      );
+    } else {
+      return MenuItem(text: line);
+    }
+  }
+
+  /// Builds a hierarchical menu structure from a flat list of items with levels.
+  /// Items at level N become children of the nearest preceding item at level N-1.
+  static List<MenuItem> _buildHierarchy(List<_FlatMenuItem> flatItems) {
+    if (flatItems.isEmpty) return [];
+
+    final result = <MenuItem>[];
+    final stack = <_StackEntry>[];
+
+    for (final flatItem in flatItems) {
+      final level = flatItem.level;
+      final item = flatItem.item;
+
+      // Pop stack until we find a parent at level-1 or stack is empty
+      while (stack.isNotEmpty && stack.last.level >= level) {
+        stack.removeLast();
+      }
+
+      if (stack.isEmpty) {
+        // This is a root-level item
+        result.add(item);
+        stack.add(_StackEntry(level: level, item: item, listRef: result));
+      } else {
+        // This item is a child of the last item in stack
+        final parent = stack.last;
+        final parentItem = parent.item;
+
+        // Get or create submenu list for parent
+        List<MenuItem> submenu;
+        if (parentItem.submenu != null) {
+          submenu = parentItem.submenu!;
+        } else {
+          submenu = <MenuItem>[];
+          // We need to update the parent in its list
+          final parentIndex = parent.listRef.indexOf(parentItem);
+          if (parentIndex >= 0) {
+            parent.listRef[parentIndex] = parentItem.copyWith(submenu: submenu);
+            // Update stack reference
+            stack[stack.length - 1] = _StackEntry(
+              level: parent.level,
+              item: parent.listRef[parentIndex],
+              listRef: parent.listRef,
+            );
+          }
+        }
+
+        submenu.add(item);
+        stack.add(_StackEntry(level: level, item: item, listRef: submenu));
+      }
+    }
+
+    return result;
   }
 
   static ({String icon, String? text}) _parseIconAndText(String input) {
@@ -278,4 +373,25 @@ class OutputParser {
 
     return null;
   }
+}
+
+/// Helper class for building hierarchical menu from flat list.
+class _FlatMenuItem {
+  const _FlatMenuItem({required this.level, required this.item});
+
+  final int level;
+  final MenuItem item;
+}
+
+/// Helper class for stack-based hierarchy building.
+class _StackEntry {
+  const _StackEntry({
+    required this.level,
+    required this.item,
+    required this.listRef,
+  });
+
+  final int level;
+  final MenuItem item;
+  final List<MenuItem> listRef;
 }

--- a/lib/services/tray_service.dart
+++ b/lib/services/tray_service.dart
@@ -7,7 +7,7 @@ import 'package:path/path.dart' as p;
 import 'package:tray_manager/tray_manager.dart';
 
 import '../core/plugin_manager.dart';
-import '../models/plugin_output.dart' hide MenuItem;
+import '../models/plugin_output.dart' as plugin_model;
 import 'logger_service.dart';
 import 'scheduler_service.dart';
 import 'window_service.dart';
@@ -25,7 +25,7 @@ class TrayService with TrayListener {
   static final TrayService _instance = TrayService._internal();
 
   final PluginManager _pluginManager = PluginManager();
-  final Map<String, PluginOutput> _pluginOutputs = {};
+  final Map<String, plugin_model.PluginOutput> _pluginOutputs = {};
 
   bool _initialized = false;
   String? _iconPath;
@@ -143,14 +143,25 @@ class TrayService with TrayListener {
   Future<void> _updateMenu() async {
     final menuItems = <MenuItem>[];
 
-    // Plugin outputs - show enabled plugins
+    // Plugin outputs - show enabled plugins with their menus
     for (final plugin in _pluginManager.plugins.where((p) => p.enabled)) {
       final output = _pluginOutputs[plugin.id];
       if (output != null && output.text != null && output.text!.isNotEmpty) {
-        menuItems.add(MenuItem(
-          label: '${output.icon} ${output.text}',
-          disabled: true,
-        ));
+        // Check if plugin has menu items to create submenu
+        if (output.menu.isNotEmpty) {
+          // Create submenu with plugin menu items
+          final submenuItems = _convertPluginMenuItems(output.menu, plugin.id);
+          menuItems.add(MenuItem.submenu(
+            label: '${output.icon} ${output.text}',
+            submenu: Menu(items: submenuItems),
+          ));
+        } else {
+          // No submenu, just show the label
+          menuItems.add(MenuItem(
+            label: '${output.icon} ${output.text}',
+            disabled: true,
+          ));
+        }
       }
     }
 
@@ -182,7 +193,86 @@ class TrayService with TrayListener {
     }
   }
 
-  void updatePluginOutput(String pluginId, PluginOutput output) {
+  /// Converts plugin MenuItem list to tray_manager MenuItem list recursively.
+  /// Supports nested submenus up to 10 levels deep (to prevent infinite loops).
+  List<MenuItem> _convertPluginMenuItems(
+    List<plugin_model.MenuItem> items,
+    String pluginId, [
+    int depth = 0,
+  ]) {
+    // Limit depth to prevent issues (GNOME has submenu rendering limitations)
+    const maxDepth = 10;
+    if (depth >= maxDepth) {
+      LoggerService().warning(
+        'Max submenu depth ($maxDepth) reached for plugin $pluginId',
+      );
+      return [];
+    }
+
+    final result = <MenuItem>[];
+    var itemIndex = 0;
+
+    for (final item in items) {
+      if (item.separator) {
+        result.add(MenuItem.separator());
+      } else if (item.submenu != null && item.submenu!.isNotEmpty) {
+        // Recursive submenu
+        final submenuItems = _convertPluginMenuItems(
+          item.submenu!,
+          pluginId,
+          depth + 1,
+        );
+        result.add(MenuItem.submenu(
+          label: item.text ?? '',
+          submenu: Menu(items: submenuItems),
+        ));
+      } else {
+        // Regular menu item with optional action
+        final key = 'plugin_${pluginId}_${depth}_$itemIndex';
+        result.add(MenuItem(
+          key: key,
+          label: item.text ?? '',
+        ));
+        // Store action for later execution
+        _registerMenuItemAction(key, item);
+      }
+      itemIndex++;
+    }
+
+    return result;
+  }
+
+  // Map to store menu item actions for execution
+  final Map<String, plugin_model.MenuItem> _menuItemActions = {};
+
+  /// Registers a menu item action for later execution when clicked.
+  void _registerMenuItemAction(String key, plugin_model.MenuItem item) {
+    _menuItemActions[key] = item;
+  }
+
+  /// Executes the action associated with a plugin menu item.
+  Future<void> _executeMenuItemAction(String key) async {
+    final item = _menuItemActions[key];
+    if (item == null) return;
+
+    if (item.href != null && item.href!.isNotEmpty) {
+      // Open URL
+      try {
+        await Process.run('xdg-open', [item.href!]);
+      } catch (e) {
+        LoggerService().warning('Failed to open URL: ${item.href} - $e');
+      }
+    } else if (item.bash != null && item.bash!.isNotEmpty) {
+      // Execute bash command
+      try {
+        await Process.run('bash', ['-c', item.bash!]);
+      } catch (e) {
+        LoggerService().warning('Failed to execute bash: ${item.bash} - $e');
+      }
+    }
+  }
+
+  void updatePluginOutput(String pluginId, plugin_model.PluginOutput output) {
     _pluginOutputs[pluginId] = output;
     _updateMenu();
     _updateTitle(pluginId, output);
@@ -214,7 +304,7 @@ class TrayService with TrayListener {
     }
   }
 
-  Future<void> _updateTitle(String pluginId, PluginOutput output) async {
+  Future<void> _updateTitle(String pluginId, plugin_model.PluginOutput output) async {
     // Find the first enabled plugin to use as the main tray title
     final firstEnabled =
         _pluginManager.plugins.where((p) => p.enabled).firstOrNull;
@@ -254,13 +344,21 @@ class TrayService with TrayListener {
 
   @override
   void onTrayMenuItemClick(MenuItem menuItem) {
-    switch (menuItem.key) {
+    final key = menuItem.key;
+    if (key == null) return;
+
+    switch (key) {
       case 'show':
         WindowService().show();
       case 'refresh':
         SchedulerService().refreshAll();
       case 'quit':
         WindowService().quit();
+      default:
+        // Check if it's a plugin menu item action
+        if (key.startsWith('plugin_')) {
+          _executeMenuItemAction(key);
+        }
     }
   }
 

--- a/plugins/submenu-demo.1m.lua
+++ b/plugins/submenu-demo.1m.lua
@@ -1,0 +1,57 @@
+-- submenu-demo.1m.lua
+-- Demonstrates hierarchical submenu support using BitBar/Argos -- prefix notation.
+-- This plugin showcases nested menus up to 3 levels deep.
+
+-- Main output line
+print("Submenus Demo")
+print("---")
+
+-- Simple flat items (no submenu)
+print("Flat Item 1")
+print("Flat Item 2")
+print("---")
+
+-- Single-level submenu using -- prefix
+print("File Actions")
+print("--Open | bash=xdg-open .")
+print("--Save")
+print("--Close")
+print("---")
+
+-- Multi-level nested submenu
+print("Settings")
+print("--Display")
+print("----Brightness")
+print("------Low")
+print("------Medium")
+print("------High")
+print("----Resolution")
+print("------1080p")
+print("------1440p")
+print("------4K")
+print("--Audio")
+print("----Volume")
+print("------25%")
+print("------50%")
+print("------75%")
+print("------100%")
+print("----Output Device")
+print("------Speakers")
+print("------Headphones")
+print("--Network")
+print("----WiFi")
+print("----Ethernet")
+print("---")
+
+-- Items with attributes in submenus
+print("Quick Links")
+print("--GitHub | href=https://github.com")
+print("--Google | href=https://google.com | color=blue")
+print("--Terminal | bash=x-terminal-emulator")
+print("---")
+
+-- Mixed content
+print("More Options")
+print("--Option A")
+print("--Option B")
+print("Another Flat Item")

--- a/test/unit/core/output_parser_test.dart
+++ b/test/unit/core/output_parser_test.dart
@@ -105,6 +105,159 @@ Menu Item
         expect(output.menu.length, 1);
         expect(output.menu[0].text, 'Menu Item');
       });
+
+      test('parses single-level submenu with -- prefix', () {
+        const input = '''
+Main
+---
+Parent Item
+--Child 1
+--Child 2
+''';
+
+        final output = OutputParser.parse(input, 'test.sh');
+
+        expect(output.text, 'Main');
+        expect(output.menu.length, 1);
+        expect(output.menu[0].text, 'Parent Item');
+        expect(output.menu[0].submenu, isNotNull);
+        expect(output.menu[0].submenu!.length, 2);
+        expect(output.menu[0].submenu![0].text, 'Child 1');
+        expect(output.menu[0].submenu![1].text, 'Child 2');
+      });
+
+      test('parses multi-level nested submenus', () {
+        const input = '''
+Test
+---
+Level 0
+--Level 1
+----Level 2
+------Level 3
+''';
+
+        final output = OutputParser.parse(input, 'test.sh');
+
+        expect(output.menu.length, 1);
+        expect(output.menu[0].text, 'Level 0');
+
+        final level1 = output.menu[0].submenu;
+        expect(level1, isNotNull);
+        expect(level1!.length, 1);
+        expect(level1[0].text, 'Level 1');
+
+        final level2 = level1[0].submenu;
+        expect(level2, isNotNull);
+        expect(level2!.length, 1);
+        expect(level2[0].text, 'Level 2');
+
+        final level3 = level2[0].submenu;
+        expect(level3, isNotNull);
+        expect(level3!.length, 1);
+        expect(level3[0].text, 'Level 3');
+      });
+
+      test('parses submenu items with attributes', () {
+        const input = '''
+Menu
+---
+Actions
+--Open | bash=/usr/bin/open
+--Visit | href=https://example.com
+--Error | color=red
+''';
+
+        final output = OutputParser.parse(input, 'test.sh');
+
+        expect(output.menu.length, 1);
+        expect(output.menu[0].text, 'Actions');
+
+        final submenu = output.menu[0].submenu;
+        expect(submenu, isNotNull);
+        expect(submenu!.length, 3);
+        expect(submenu[0].text, 'Open');
+        expect(submenu[0].bash, '/usr/bin/open');
+        expect(submenu[1].text, 'Visit');
+        expect(submenu[1].href, 'https://example.com');
+        expect(submenu[2].text, 'Error');
+        expect(submenu[2].color, 'red');
+      });
+
+      test('parses multiple parent items with submenus', () {
+        const input = '''
+Test
+---
+Parent A
+--Child A1
+--Child A2
+Parent B
+--Child B1
+''';
+
+        final output = OutputParser.parse(input, 'test.sh');
+
+        expect(output.menu.length, 2);
+
+        expect(output.menu[0].text, 'Parent A');
+        expect(output.menu[0].submenu!.length, 2);
+        expect(output.menu[0].submenu![0].text, 'Child A1');
+        expect(output.menu[0].submenu![1].text, 'Child A2');
+
+        expect(output.menu[1].text, 'Parent B');
+        expect(output.menu[1].submenu!.length, 1);
+        expect(output.menu[1].submenu![0].text, 'Child B1');
+      });
+
+      test('handles mixed flat and nested items', () {
+        const input = '''
+App
+---
+Flat Item 1
+Parent
+--Nested Item
+Flat Item 2
+''';
+
+        final output = OutputParser.parse(input, 'test.sh');
+
+        expect(output.menu.length, 3);
+        expect(output.menu[0].text, 'Flat Item 1');
+        expect(output.menu[0].submenu, isNull);
+
+        expect(output.menu[1].text, 'Parent');
+        expect(output.menu[1].submenu, isNotNull);
+        expect(output.menu[1].submenu!.length, 1);
+
+        expect(output.menu[2].text, 'Flat Item 2');
+        expect(output.menu[2].submenu, isNull);
+      });
+
+      test('handles submenu with 5 nesting levels', () {
+        const input = '''
+Deep
+---
+L0
+--L1
+----L2
+------L3
+--------L4
+----------L5
+''';
+
+        final output = OutputParser.parse(input, 'test.sh');
+
+        expect(output.menu.length, 1);
+
+        var current = output.menu[0];
+        expect(current.text, 'L0');
+
+        for (var i = 1; i <= 5; i++) {
+          expect(current.submenu, isNotNull, reason: 'Level $i should exist');
+          expect(current.submenu!.length, 1);
+          current = current.submenu![0];
+          expect(current.text, 'L$i');
+        }
+      });
     });
 
     group('parse - JSON format', () {


### PR DESCRIPTION
…bility

This commit implements full hierarchical submenu support using the BitBar/Argos -- prefix notation, enabling multi-level menu structures in plugin outputs.

Changes:
- OutputParser: Added hierarchy level detection via -- prefix pairs
- OutputParser: New _buildHierarchy algorithm for flat-to-tree conversion
- TrayService: Recursive menu rendering with MenuItem.submenu support
- TrayService: Action execution for submenu items (bash/href)
- Added submenu-demo.1m.lua example plugin
- Expanded documentation with practical examples
- Added comprehensive unit tests for 2-5 nesting levels

Closes #37