### PR TITLE
Add screenshot command to CLI

### DIFF
--- a/lib/cli/cli_handler.dart
+++ b/lib/cli/cli_handler.dart
@@ -7,13 +7,14 @@ import 'commands/bluetooth_command.dart';
 import 'commands/clipboard_command.dart';
 import 'commands/dnd_command.dart';
 import 'commands/filesystem_commands.dart';
-import 'commands/media_command.dart';
 import 'commands/location_command.dart';
+import 'commands/media_command.dart';
 import 'commands/network_command.dart';
 import 'commands/plugin_commands.dart';
 import 'commands/power_command.dart';
 import 'commands/qr_command.dart';
 import 'commands/screen_command.dart';
+import 'commands/screenshot_command.dart';
 import 'commands/system_info_commands.dart';
 import 'commands/utility_commands.dart';
 import 'commands/vpn_command.dart';
@@ -54,6 +55,7 @@ void _registerCommands() {
   _register(NotifyCommand());
   _register(OpenCommand());
   _register(QrCommand());
+  _register(ScreenshotCommand());
 
   // Misc
   _register(TimeCommand());
@@ -224,6 +226,7 @@ Utilities:
   open file <path>          Open file
   open app <name>           Launch application
   qr <text>                 Generate QR Code
+  screenshot [path]         Take screenshot (or --clipboard)
 
   time                      Current time
   date                      Current date

--- a/lib/cli/commands/screenshot_command.dart
+++ b/lib/cli/commands/screenshot_command.dart
@@ -1,0 +1,51 @@
+// ignore_for_file: avoid_print
+import 'dart:io';
+
+import '../../core/api/utils_api.dart';
+import 'base_command.dart';
+
+class ScreenshotCommand extends CliCommand {
+  ScreenshotCommand({this.api = const UtilsApi()});
+
+  final UtilsApi api;
+
+  @override
+  String get name => 'screenshot';
+
+  @override
+  String get description => 'Take a screenshot';
+
+  @override
+  Future<int> execute(List<String> args) async {
+    String? path;
+    var toClipboard = false;
+
+    // Parse args
+    if (args.contains('--clipboard') || args.contains('-c')) {
+      toClipboard = true;
+    }
+
+    final values = args.where((a) => !a.startsWith('-')).toList();
+    if (values.isNotEmpty) {
+      path = values[0];
+    }
+
+    final jsonOutput = args.contains('--json');
+    final xmlOutput = args.contains('--xml');
+
+    final result = await api.takeScreenshot(path: path, toClipboard: toClipboard);
+
+    if (result != null) {
+       printFormatted(
+            {'success': true, 'path': result, 'clipboard': toClipboard},
+            json: jsonOutput,
+            xml: xmlOutput,
+            plain: (_) => toClipboard ? 'Screenshot copied to clipboard' : 'Screenshot saved to $result'
+        );
+        return 0;
+    } else {
+        stderr.writeln('Failed to take screenshot');
+        return 1;
+    }
+  }
+}

--- a/packages/crossbar_cli/lib/src/cli_handler.dart
+++ b/packages/crossbar_cli/lib/src/cli_handler.dart
@@ -7,13 +7,14 @@ import 'commands/bluetooth_command.dart';
 import 'commands/clipboard_command.dart';
 import 'commands/dnd_command.dart';
 import 'commands/filesystem_commands.dart';
-import 'commands/media_command.dart';
 import 'commands/location_command.dart';
+import 'commands/media_command.dart';
 import 'commands/network_command.dart';
 import 'commands/plugin_commands.dart';
 import 'commands/power_command.dart';
 import 'commands/qr_command.dart';
 import 'commands/screen_command.dart';
+import 'commands/screenshot_command.dart';
 import 'commands/system_info_commands.dart';
 import 'commands/utility_commands.dart';
 import 'commands/vpn_command.dart';
@@ -54,6 +55,7 @@ void _registerCommands() {
   _register(NotifyCommand());
   _register(OpenCommand());
   _register(QrCommand());
+  _register(ScreenshotCommand());
 
   // Misc
   _register(TimeCommand());
@@ -224,6 +226,7 @@ Utilities:
   open file <path>          Open file
   open app <name>           Launch application
   qr <text>                 Generate QR Code
+  screenshot [path]         Take screenshot (or --clipboard)
 
   time                      Current time
   date                      Current date

--- a/packages/crossbar_cli/lib/src/commands/screenshot_command.dart
+++ b/packages/crossbar_cli/lib/src/commands/screenshot_command.dart
@@ -1,0 +1,51 @@
+// ignore_for_file: avoid_print
+import 'dart:io';
+
+import 'package:crossbar_core/crossbar_core.dart';
+import 'base_command.dart';
+
+class ScreenshotCommand extends CliCommand {
+  ScreenshotCommand({this.api = const UtilsApi()});
+
+  final UtilsApi api;
+
+  @override
+  String get name => 'screenshot';
+
+  @override
+  String get description => 'Take a screenshot';
+
+  @override
+  Future<int> execute(List<String> args) async {
+    String? path;
+    var toClipboard = false;
+
+    // Parse args
+    if (args.contains('--clipboard') || args.contains('-c')) {
+      toClipboard = true;
+    }
+
+    final values = args.where((a) => !a.startsWith('-')).toList();
+    if (values.isNotEmpty) {
+      path = values[0];
+    }
+
+    final jsonOutput = args.contains('--json');
+    final xmlOutput = args.contains('--xml');
+
+    final result = await api.takeScreenshot(path: path, toClipboard: toClipboard);
+
+    if (result != null) {
+       printFormatted(
+            {'success': true, 'path': result, 'clipboard': toClipboard},
+            json: jsonOutput,
+            xml: xmlOutput,
+            plain: (_) => toClipboard ? 'Screenshot copied to clipboard' : 'Screenshot saved to $result'
+        );
+        return 0;
+    } else {
+        stderr.writeln('Failed to take screenshot');
+        return 1;
+    }
+  }
+}

--- a/test/unit/cli/screenshot_command_test.dart
+++ b/test/unit/cli/screenshot_command_test.dart
@@ -1,0 +1,75 @@
+import 'package:crossbar/cli/commands/screenshot_command.dart';
+import 'package:crossbar/core/api/utils_api.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class TestUtilsApi extends UtilsApi {
+  String? result = '/tmp/screenshot.png';
+  String? capturedPath;
+  bool? capturedClipboard;
+
+  @override
+  Future<String?> takeScreenshot({String? path, bool toClipboard = false}) async {
+    capturedPath = path;
+    capturedClipboard = toClipboard;
+    return result;
+  }
+}
+
+void main() {
+  group('ScreenshotCommand', () {
+    late ScreenshotCommand command;
+    late TestUtilsApi testApi;
+
+    setUp(() {
+      testApi = TestUtilsApi();
+      command = ScreenshotCommand(api: testApi);
+    });
+
+    test('name is screenshot', () {
+      expect(command.name, 'screenshot');
+    });
+
+    test('description is not empty', () {
+      expect(command.description, isNotEmpty);
+    });
+
+    test('executes successfully and returns 0', () async {
+      testApi.result = '/tmp/screenshot.png';
+
+      final exitCode = await command.execute(['/tmp/screenshot.png']);
+
+      expect(exitCode, 0);
+      expect(testApi.capturedPath, '/tmp/screenshot.png');
+      expect(testApi.capturedClipboard, false);
+    });
+
+    test('handles --clipboard flag', () async {
+      testApi.result = 'clipboard';
+
+      final exitCode = await command.execute(['--clipboard']);
+
+      expect(exitCode, 0);
+      expect(testApi.capturedPath, isNull);
+      expect(testApi.capturedClipboard, true);
+    });
+
+    test('handles -c flag', () async {
+      testApi.result = 'clipboard';
+
+      final exitCode = await command.execute(['-c']);
+
+      expect(exitCode, 0);
+      expect(testApi.capturedClipboard, true);
+    });
+
+    test('handles failure and returns 1', () async {
+      testApi.result = null;
+
+      final exitCode = await command.execute([]);
+
+      expect(exitCode, 1);
+      expect(testApi.capturedPath, isNull);
+      expect(testApi.capturedClipboard, false);
+    });
+  });
+}


### PR DESCRIPTION
Added `screenshot` command to Crossbar CLI.

This command allows users to take screenshots from the command line, either saving to a file or copying to the clipboard.
It utilizes the existing `UtilsApi` which supports Linux (gnome-screenshot, scrot, spectacle), macOS (screencapture), and Windows (PowerShell).

Usage:
`crossbar screenshot [path]`
`crossbar screenshot --clipboard`

The command is available in both the standalone CLI binary (`packages/crossbar_cli`) and the internal CLI handler (`lib/cli`), ensuring consistency across platforms and usage contexts.


---
*PR created automatically by Jules for task [12344176955903337611](https://jules.google.com/task/12344176955903337611) started by @insign*