### PR TITLE
feat(tray): implement smart overflow display mode

### DIFF
--- a/lib/services/tray_service.dart
+++ b/lib/services/tray_service.dart
@@ -2,14 +2,14 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:ui';
 
+import 'package:crossbar/core/plugin_manager.dart';
+import 'package:crossbar_core/crossbar_core.dart' as plugin_model;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:path/path.dart' as p;
 import 'package:tray_manager/tray_manager.dart';
 
-import '../core/plugin_manager.dart';
-import 'package:crossbar_core/crossbar_core.dart' as plugin_model;
 import 'logger_service.dart';
 import 'refresh_service.dart';
 import 'scheduler_service.dart';
@@ -41,6 +41,12 @@ class TrayService with TrayListener {
   TrayBackend? _backend;
   final Map<String, int> _pluginIconIds = {}; // pluginId -> iconId
 
+  /// Set the backend for testing purposes.
+  @visibleForTesting
+  set backendForTesting(TrayBackend backend) {
+    _backend = backend;
+  }
+
   bool _initialized = false;
   bool _unifiedTrayActive = false; // Tracks if unified tray_manager is active
   String? _iconPath;
@@ -51,10 +57,23 @@ class TrayService with TrayListener {
   TrayDisplayMode get _displayMode => SettingsService().trayDisplayMode;
 
   /// Returns true if separate mode is active and supported.
-  bool get _useSeparateMode =>
-      _displayMode == TrayDisplayMode.separate &&
-      _backend != null &&
-      _backend!.supportsMultipleIcons;
+  bool get _useSeparateMode {
+    if (_backend == null || !_backend!.supportsMultipleIcons) {
+      return false;
+    }
+
+    if (_displayMode == TrayDisplayMode.separate) {
+      return true;
+    }
+
+    if (_displayMode == TrayDisplayMode.smartOverflow) {
+      final enabledCount =
+          _pluginManager.plugins.where((p) => p.enabled).length;
+      return enabledCount <= SettingsService().trayClusterThreshold;
+    }
+
+    return false;
+  }
 
   Future<void> init() async {
     if (_initialized) return;
@@ -65,14 +84,23 @@ class TrayService with TrayListener {
     // Resolve icon path first
     await _resolveIconPath();
 
+    // Initialize the backend if not already set (e.g. for testing)
     // Initialize the hybrid backend for potential multi-icon support
-    _backend = HybridTrayBackend();
+    _backend ??= HybridTrayBackend();
+
     final backendInitialized = await _backend!.init();
 
     if (backendInitialized) {
-      LoggerService().info(
-        'TrayService: Backend initialized - ${(_backend as HybridTrayBackend).activeBackendName}',
-      );
+      // Check if backend is HybridTrayBackend before casting
+      if (_backend is HybridTrayBackend) {
+        LoggerService().info(
+          'TrayService: Backend initialized - ${(_backend as HybridTrayBackend).activeBackendName}',
+        );
+      } else {
+        LoggerService().info(
+          'TrayService: Backend initialized - ${_backend!.name}',
+        );
+      }
       LoggerService().info(
         'TrayService: Multi-icon support: ${_backend!.supportsMultipleIcons}',
       );
@@ -487,16 +515,24 @@ class TrayService with TrayListener {
 
   /// Public method to refresh the tray menu.
   Future<void> refreshMenu() async {
-    if (_useSeparateMode) {
-      await _cleanupSeparateIcons();
-      // Recreate icons for all enabled plugins with output
+    final useSeparate = _useSeparateMode;
+
+    if (useSeparate) {
+      // Switch to Separate Mode (or keep using it)
+      await _cleanupSeparateIcons(); // Remove icons for disabled plugins
+      // Create/Update separate icons for enabled plugins
       for (final plugin in _pluginManager.plugins.where((p) => p.enabled)) {
         final output = _pluginOutputs[plugin.id];
         if (output != null) {
           await _updateSeparateIcon(plugin.id, output);
         }
       }
+      // Ensure unified menu is clean (only system items)
+      await _updateUnifiedMenu();
     } else {
+      // Switch to Unified Mode (or keep using it)
+      await _removeAllSeparateIcons();
+      // Update unified menu to include plugins
       await _updateUnifiedMenu();
     }
   }
@@ -524,6 +560,17 @@ class TrayService with TrayListener {
         LoggerService().info('Removed separate tray icon for plugin $pluginId');
       }
     }
+  }
+
+  /// Removes all separate icons (used when switching to unified mode).
+  Future<void> _removeAllSeparateIcons() async {
+    if (_backend == null) return;
+
+    for (final iconId in _pluginIconIds.values) {
+      await _backend!.destroyIcon(iconId);
+    }
+    _pluginIconIds.clear();
+    LoggerService().info('Removed all separate tray icons');
   }
 
   void _updateTooltip() {

--- a/test/unit/services/tray_service_smart_overflow_test.dart
+++ b/test/unit/services/tray_service_smart_overflow_test.dart
@@ -1,0 +1,243 @@
+// ignore_for_file: avoid_slow_async_io
+import 'dart:io';
+
+import 'package:crossbar/core/plugin_manager.dart';
+import 'package:crossbar/services/settings_service.dart';
+import 'package:crossbar/services/tray/tray_backend.dart';
+import 'package:crossbar/services/tray/tray_menu_item.dart';
+import 'package:crossbar/services/tray_service.dart';
+import 'package:crossbar_core/crossbar_core.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// Fake TrayBackend that records calls
+class FakeTrayBackend implements TrayBackend {
+  final List<String> calls = [];
+
+  @override
+  String get name => 'FakeTrayBackend';
+
+  @override
+  bool get supportsMultipleIcons => true;
+
+  @override
+  int get maxIcons => 10;
+
+  @override
+  bool get isInitialized => true;
+
+  @override
+  Future<bool> init() async {
+    calls.add('init');
+    return true;
+  }
+
+  @override
+  Future<int?> createIcon({
+    required String pluginId,
+    required String iconPath,
+    required String tooltip,
+  }) async {
+    calls.add('createIcon($pluginId)');
+    return pluginId.hashCode;
+  }
+
+  @override
+  Future<void> destroyIcon(int iconId) async {
+    calls.add('destroyIcon($iconId)');
+  }
+
+  @override
+  Future<void> updateIcon({
+    required int iconId,
+    String? iconPath,
+    String? title,
+    String? tooltip,
+    List<TrayMenuItem>? menu,
+  }) async {
+    calls.add('updateIcon($iconId, $title)');
+  }
+
+  @override
+  Future<void> dispose() async {
+    calls.add('dispose');
+  }
+
+  // Not used but required by interface if any
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TrayService Smart Overflow', () {
+    late TrayService trayService;
+    late Directory tempDir;
+    late FakeTrayBackend fakeBackend;
+    final log = <MethodCall>[];
+
+    setUp(() async {
+      // Mock TrayManager channel
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        const MethodChannel('tray_manager'),
+        (MethodCall methodCall) async {
+          log.add(methodCall);
+          return null;
+        },
+      );
+
+      // Reset SettingsService
+      SettingsService().resetForTesting();
+      SharedPreferences.setMockInitialValues({
+        'tray_display_mode': 'smartOverflow',
+        'tray_cluster_threshold': 2,
+      });
+      await SettingsService().init();
+
+      // Setup PluginManager with dummy plugins directory
+      tempDir = Directory.systemTemp.createTempSync();
+
+      final pm = PluginManager();
+      pm.customPluginsDirectory = tempDir.path;
+      await pm.discoverPlugins(); // Should result in 0 plugins
+
+      // Setup TrayService with FakeBackend
+      trayService = TrayService();
+      await trayService.dispose();
+
+      fakeBackend = FakeTrayBackend();
+      trayService.backendForTesting = fakeBackend;
+    });
+
+    tearDown(() async {
+      await trayService.dispose();
+      try {
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      } catch (_) {}
+      log.clear();
+    });
+
+    Future<void> createPluginFile(String name) async {
+      final pluginFile = File('${tempDir.path}/$name');
+      pluginFile.writeAsStringSync('#!/bin/bash\necho "test"');
+      if (Platform.isLinux || Platform.isMacOS) {
+        Process.runSync('chmod', ['+x', pluginFile.path]);
+      }
+    }
+
+    test('should use separate mode when plugin count <= threshold', () async {
+      if (!Platform.isLinux && !Platform.isMacOS && !Platform.isWindows) {
+        return; // Skip on mobile
+      }
+
+      await createPluginFile('p1.sh');
+      await PluginManager().discoverPlugins();
+
+      // Initialize TrayService
+      await trayService.init();
+
+      // Add output for plugin
+      final p1 = PluginManager().plugins.first;
+      trayService.updatePluginOutput(
+        p1.id,
+        PluginOutput(pluginId: p1.id, text: 'P1', icon: '🚀'),
+      );
+      await Future.delayed(Duration.zero);
+
+      // Expect: createIcon called (Separate Mode)
+      // Because 1 plugin <= threshold 2
+      expect(fakeBackend.calls, contains('createIcon(${p1.id})'));
+
+      // Verify updateIcon called with title containing icon + text
+      expect(fakeBackend.calls, contains(matches(r'updateIcon\(\d+, 🚀 P1\)')));
+    });
+
+    test('should switch to unified mode when plugin count > threshold', () async {
+      if (!Platform.isLinux && !Platform.isMacOS && !Platform.isWindows) {
+        return;
+      }
+
+      // Threshold is 2.
+      await createPluginFile('p1.sh');
+      await createPluginFile('p2.sh');
+      await PluginManager().discoverPlugins();
+
+      await trayService.init();
+
+      // Should start in separate mode (2 <= 2)
+      final p1 = PluginManager().plugins.firstWhere((p) => p.id == 'p1.sh');
+      final p2 = PluginManager().plugins.firstWhere((p) => p.id == 'p2.sh');
+
+      trayService.updatePluginOutput(
+        p1.id,
+        PluginOutput(pluginId: p1.id, text: 'P1', icon: '🚀'),
+      );
+      trayService.updatePluginOutput(
+        p2.id,
+        PluginOutput(pluginId: p2.id, text: 'P2', icon: '👾'),
+      );
+      await Future.delayed(Duration.zero);
+
+      expect(fakeBackend.calls, contains('createIcon(${p1.id})'));
+      expect(fakeBackend.calls, contains('createIcon(${p2.id})'));
+
+      // Now add 3rd plugin
+      await createPluginFile('p3.sh');
+      await PluginManager().discoverPlugins(); // Rediscover
+
+      await trayService.refreshMenu();
+
+      // Now 3 plugins > threshold 2. Should switch to Unified.
+      // Expect: destroyIcon called for p1 and p2
+      expect(fakeBackend.calls, contains('destroyIcon(${p1.id.hashCode})'));
+      expect(fakeBackend.calls, contains('destroyIcon(${p2.id.hashCode})'));
+
+      // Also verify unified menu updated with plugins
+      final contextMenuCalls = log.where((c) => c.method == 'setContextMenu');
+      expect(contextMenuCalls, isNotEmpty);
+    });
+
+    test('should switch back to separate mode when plugin count decreases', () async {
+      if (!Platform.isLinux && !Platform.isMacOS && !Platform.isWindows) {
+        return;
+      }
+
+      // Threshold 2. Start with 3.
+      await createPluginFile('p1.sh');
+      await createPluginFile('p2.sh');
+      await createPluginFile('p3.sh');
+      await PluginManager().discoverPlugins();
+
+      await trayService.init();
+
+      // Trigger refresh to settle state (Unified)
+      await trayService.refreshMenu();
+
+      // Provide output for all
+      final p1 = PluginManager().plugins.firstWhere((p) => p.id == 'p1.sh');
+      trayService.updatePluginOutput(
+        p1.id,
+        PluginOutput(pluginId: p1.id, text: 'P1', icon: '🚀'),
+      );
+      await Future.delayed(Duration.zero);
+
+      // Clear calls to focus on transition
+      fakeBackend.calls.clear();
+
+      // Remove P3
+      final p3File = File('${tempDir.path}/p3.sh');
+      p3File.deleteSync();
+      await PluginManager().discoverPlugins();
+
+      // Trigger refresh (simulate notification)
+      await trayService.refreshMenu();
+
+      // Now 2 plugins <= threshold 2. Should switch to Separate.
+      // Expect: createIcon for p1
+      expect(fakeBackend.calls, contains('createIcon(${p1.id})'));
+    });
+  });
+}


### PR DESCRIPTION
Implemented the `TrayDisplayMode.smartOverflow` logic in `TrayService`. This feature allows the tray to dynamically switch between showing separate icons for each plugin (when the count is low) and a single unified icon (when the count exceeds a threshold).

Key changes:
- Modified `TrayService` to include `_shouldUseSeparateMode` logic which respects `smartOverflow` setting.
- Updated `refreshMenu` to handle transitions between modes (cleaning up separate icons or the unified menu as needed).
- Added `test/unit/services/tray_service_smart_overflow_test.dart` to verify the logic with a fake backend.
- Minor code cleanup and formatting in `TrayService`.

---
*PR created automatically by Jules for task [12671993474141497617](https://jules.google.com/task/12671993474141497617) started by @insign*