### PR TITLE
Enable absolute seek support in MediaApi

### DIFF
--- a/lib/core/api/media_api.dart
+++ b/lib/core/api/media_api.dart
@@ -175,27 +175,43 @@ class MediaApi {
     }
   }
 
-  /// Seek relative position (e.g., "+30", "-10" in seconds)
+  /// Seek relative or absolute position (e.g., "+30", "-10", "60")
   Future<bool> seek(String offset) async {
     try {
-      // Parse offset string like "+30s", "-10s", "+30", "-10"
-      final cleanOffset = offset.replaceAll('s', '');
+      final isRelative =
+          offset.trim().startsWith('+') || offset.trim().startsWith('-');
+
+      // Parse offset string like "+30s", "-10s", "+30", "-10", "60"
+      final cleanOffset = offset.replaceAll('s', '').replaceAll('+', '');
       final seconds = int.tryParse(cleanOffset) ?? 0;
 
       if (Platform.isLinux) {
-        // playerctl position expects offset in seconds with +/- prefix
+        // playerctl position:
+        // - "+10" or "-10" -> relative seek
+        // - "10" -> absolute seek
+        String arg;
+        if (isRelative) {
+          arg = '${seconds >= 0 ? '+' : ''}$seconds';
+        } else {
+          arg = '$seconds';
+        }
+
         final result = await Process.run('playerctl', [
           'position',
-          '${seconds >= 0 ? '+' : ''}$seconds',
+          arg,
         ]);
         return result.exitCode == 0;
       }
       if (Platform.isMacOS) {
+        final script = isRelative
+            ? 'set player position to (player position + $seconds)'
+            : 'set player position to $seconds';
+
         final result = await Process.run('osascript', [
           '-e',
           '''
           tell application "Music"
-            set player position to (player position + $seconds)
+            $script
           end tell
           ''',
         ]);

--- a/packages/crossbar_core/lib/src/api/media_api.dart
+++ b/packages/crossbar_core/lib/src/api/media_api.dart
@@ -175,27 +175,43 @@ class MediaApi {
     }
   }
 
-  /// Seek relative position (e.g., "+30", "-10" in seconds)
+  /// Seek relative or absolute position (e.g., "+30", "-10", "60")
   Future<bool> seek(String offset) async {
     try {
-      // Parse offset string like "+30s", "-10s", "+30", "-10"
-      final cleanOffset = offset.replaceAll('s', '');
+      final isRelative =
+          offset.trim().startsWith('+') || offset.trim().startsWith('-');
+
+      // Parse offset string like "+30s", "-10s", "+30", "-10", "60"
+      final cleanOffset = offset.replaceAll('s', '').replaceAll('+', '');
       final seconds = int.tryParse(cleanOffset) ?? 0;
 
       if (Platform.isLinux) {
-        // playerctl position expects offset in seconds with +/- prefix
+        // playerctl position:
+        // - "+10" or "-10" -> relative seek
+        // - "10" -> absolute seek
+        String arg;
+        if (isRelative) {
+          arg = '${seconds >= 0 ? '+' : ''}$seconds';
+        } else {
+          arg = '$seconds';
+        }
+
         final result = await Process.run('playerctl', [
           'position',
-          '${seconds >= 0 ? '+' : ''}$seconds',
+          arg,
         ]);
         return result.exitCode == 0;
       }
       if (Platform.isMacOS) {
+        final script = isRelative
+            ? 'set player position to (player position + $seconds)'
+            : 'set player position to $seconds';
+
         final result = await Process.run('osascript', [
           '-e',
           '''
           tell application "Music"
-            set player position to (player position + $seconds)
+            $script
           end tell
           ''',
         ]);

--- a/test/unit/core/api/media_api_test.dart
+++ b/test/unit/core/api/media_api_test.dart
@@ -51,6 +51,11 @@ void main() {
         final result = await api.seek('-15s');
         expect(result, isA<bool>());
       });
+
+      test('seek handles absolute position', () async {
+        final result = await api.seek('30');
+        expect(result, isA<bool>());
+      });
     });
 
     group('getPlaying', () {


### PR DESCRIPTION
Implemented absolute seek support in `MediaApi` for Linux (playerctl) and macOS (AppleScript). Previously, all seeks were forced to be relative. Now, offsets without explicit sign are treated as absolute timestamps (seconds). Added unit test case.

---
*PR created automatically by Jules for task [12420965290712975641](https://jules.google.com/task/12420965290712975641) started by @insign*