### PR TITLE
Add 'volume' CLI command alias

### DIFF
--- a/lib/cli/cli_handler.dart
+++ b/lib/cli/cli_handler.dart
@@ -17,6 +17,7 @@ import 'commands/screen_command.dart';
 import 'commands/screenshot_command.dart';
 import 'commands/system_info_commands.dart';
 import 'commands/utility_commands.dart';
+import 'commands/volume_command.dart';
 import 'commands/vpn_command.dart';
 import 'commands/wallpaper_command.dart';
 import 'commands/web_command.dart';
@@ -31,6 +32,7 @@ void _registerCommands() {
 
   // Audio & Media
   _register(AudioCommand());
+  _register(VolumeCommand());
   _register(MediaCommand());
 
   // System & Hardware
@@ -154,6 +156,7 @@ System Info (Simple Getters):
 
 Audio Controls (audio):
   audio volume [0-100]      Get volume or Set volume
+  volume [0-100]            Alias for 'audio volume'
   audio mute                Toggle mute
   audio output [device]     Get output or Set device
   audio output --list       List output devices

--- a/lib/cli/commands/volume_command.dart
+++ b/lib/cli/commands/volume_command.dart
@@ -1,0 +1,52 @@
+// ignore_for_file: avoid_print
+import 'dart:io';
+
+import '../../core/api/media_api.dart';
+import 'base_command.dart';
+
+class VolumeCommand extends CliCommand {
+  @override
+  String get name => 'volume';
+
+  @override
+  String get description => 'Control volume (alias for audio volume)';
+
+  @override
+  Future<int> execute(List<String> args) async {
+    const api = MediaApi();
+    final jsonOutput = args.contains('--json');
+    final xmlOutput = args.contains('--xml');
+    final values = args.where((a) => !a.startsWith('--')).toList();
+
+    if (values.isEmpty) {
+      // Get
+      final result = await api.getVolume();
+      printFormatted(
+        {'volume': result},
+        json: jsonOutput,
+        xml: xmlOutput,
+        plain: (_) => '$result%',
+      );
+    } else {
+      // Set
+      final level = int.tryParse(values[0]);
+      if (level == null) {
+        stderr.writeln('Error: volume requires a number (0-100)');
+        return 1;
+      }
+      final result = await api.setVolume(level);
+      if (result) {
+        printFormatted(
+          {'success': true, 'volume': level},
+          json: jsonOutput,
+          xml: xmlOutput,
+          plain: (_) => 'Volume set to $level%',
+        );
+      } else {
+        stderr.writeln('Failed to set volume');
+        return 1;
+      }
+    }
+    return 0;
+  }
+}

--- a/test/unit/cli/commands/volume_command_test.dart
+++ b/test/unit/cli/commands/volume_command_test.dart
@@ -1,0 +1,16 @@
+import 'package:crossbar/cli/commands/volume_command.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('VolumeCommand', () {
+    test('name should be volume', () {
+      final command = VolumeCommand();
+      expect(command.name, 'volume');
+    });
+
+    test('description should be descriptive', () {
+      final command = VolumeCommand();
+      expect(command.description, contains('Control volume'));
+    });
+  });
+}


### PR DESCRIPTION
Added a new `volume` command to the CLI as an alias/shortcut for `audio volume`.

- **New Command:** `volume [level]` (e.g., `crossbar volume`, `crossbar volume 50`)
- **Reasoning:** 'volume' is a very common command, and typing 'audio volume' can be tedious. This top-level alias improves the developer experience and discoverability.
- **Implementation:**
  - Created `VolumeCommand` class in `lib/cli/commands/volume_command.dart` which uses `MediaApi`.
  - Registered the command in `lib/cli/cli_handler.dart`.
  - Added unit tests.

---
*PR created automatically by Jules for task [9711632439324317873](https://jules.google.com/task/9711632439324317873) started by @insign*