### PR TITLE
feat(marketplace): implement installFromUrl functionality

### DIFF
--- a/lib/services/marketplace_service.dart
+++ b/lib/services/marketplace_service.dart
@@ -158,6 +158,54 @@ class MarketplaceService {
     return _plugins;
   }
 
+  Future<bool> installFromUrl(String url) async {
+    try {
+      _lastError = null;
+
+      final response = await _dio.get(
+        url,
+        options: Options(receiveTimeout: const Duration(seconds: 30)),
+      );
+
+      if (response.statusCode != 200) {
+        _lastError = 'Failed to download plugin: ${response.statusCode}';
+        return false;
+      }
+
+      final uri = Uri.parse(url);
+      final filename = uri.pathSegments.last;
+
+      if (filename.isEmpty || !filename.contains('.')) {
+        _lastError = 'Invalid plugin URL: must point to a file with an extension';
+        return false;
+      }
+
+      final pluginDir = await _pluginManager.pluginsDirectory;
+      final dir = Directory(pluginDir);
+      if (!dir.existsSync()) {
+        dir.createSync(recursive: true);
+      }
+
+      final filePath = p.join(pluginDir, filename);
+      final file = File(filePath);
+      final content = response.data is String ? response.data : jsonEncode(response.data);
+      await file.writeAsString(content);
+
+      // Make executable on Unix systems
+      if (Platform.isLinux || Platform.isMacOS) {
+        await Process.run('chmod', ['+x', filePath]);
+      }
+
+      // Reload plugins
+      await _pluginManager.discoverPlugins();
+
+      return true;
+    } catch (e) {
+      _lastError = e.toString();
+      return false;
+    }
+  }
+
   Future<bool> installPlugin(MarketplacePlugin plugin) async {
     try {
       _lastError = null;

--- a/lib/ui/tabs/marketplace_tab.dart
+++ b/lib/ui/tabs/marketplace_tab.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../../l10n/app_localizations.dart';
 import '../animations/animation_constants.dart';
 import '../animations/animated_dialog.dart';
+import '../../services/marketplace_service.dart';
 
 class MarketplaceTab extends StatefulWidget {
   const MarketplaceTab({super.key});
@@ -213,7 +214,7 @@ class _MarketplaceTabState extends State<MarketplaceTab> {
     );
   }
 
-  void _installFromUrl(String url) {
+  Future<void> _installFromUrl(String url) async {
     if (url.isEmpty) return;
 
     ScaffoldMessenger.of(context).showSnackBar(
@@ -222,15 +223,26 @@ class _MarketplaceTabState extends State<MarketplaceTab> {
       ),
     );
 
-    // TODO: Implement actual installation
-    Future<void>.delayed(const Duration(seconds: 2), () {
-      if (mounted) {
+    final service = MarketplaceService();
+    final success = await service.installFromUrl(url);
+
+    if (mounted) {
+      if (success) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
-            content: Text('Plugin installation coming soon!'),
+            content: Text('Plugin installed successfully!'),
+            backgroundColor: Colors.green,
+          ),
+        );
+      } else {
+        final error = service.lastError ?? 'Unknown error';
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Failed to install plugin: $error'),
+            backgroundColor: Colors.red,
           ),
         );
       }
-    });
+    }
   }
 }


### PR DESCRIPTION
Implements the actual installation logic in MarketplaceTab and MarketplaceService for installing plugins directly from a raw URL. This addresses a TODO in the codebase and improves the marketplace experience by allowing direct installations of scripts or plugins.

---
*PR created automatically by Jules for task [9757963951576089823](https://jules.google.com/task/9757963951576089823) started by @insign*