### PR TITLE
feat(settings): open plugins directory natively

### DIFF
--- a/lib/ui/tabs/settings_tab.dart
+++ b/lib/ui/tabs/settings_tab.dart
@@ -1,8 +1,10 @@
 // ignore_for_file: deprecated_member_use
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:open_filex/open_filex.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
+import '../../core/plugin_manager.dart';
 import '../../l10n/app_localizations.dart';
 import '../../services/settings_service.dart';
 import '../../services/update_service.dart';
@@ -178,8 +180,9 @@ class _SettingsTabState extends State<SettingsTab> {
                     subtitle: const Text('~/.crossbar/plugins'),
                     trailing: IconButton(
                       icon: const Icon(Icons.folder_open),
-                      onPressed: () {
-                        // TODO: Open folder
+                      onPressed: () async {
+                        final path = await PluginManager().pluginsDirectory;
+                        await OpenFilex.open(path);
                       },
                     ),
                   ),


### PR DESCRIPTION
Implemented a missing feature in the Settings Tab to allow users to open the Plugins Directory directly from the UI. This enhances the user experience by providing an easy way to manage their plugins. 

Changes:
- Added `open_filex` and `plugin_manager` imports to `lib/ui/tabs/settings_tab.dart`
- Updated the `onPressed` callback for the "Plugins Directory" `ListTile` to get the path and open it natively.

---
*PR created automatically by Jules for task [15367756638621416582](https://jules.google.com/task/15367756638621416582) started by @insign*